### PR TITLE
Patch: give absolute path to codes_ui launch script

### DIFF
--- a/recipe/0001-Give-absolute-path-to-codes_ui-launch-script.patch
+++ b/recipe/0001-Give-absolute-path-to-codes_ui-launch-script.patch
@@ -1,0 +1,25 @@
+From 21fe75dec08a025cdb74740247a192d389b4db45 Mon Sep 17 00:00:00 2001
+From: Daniel Tipping <daniel@oldreliable.tech>
+Date: Sat, 13 Apr 2019 17:22:03 +0100
+Subject: [PATCH] Give absolute path to codes_ui launch script
+
+---
+ metview/src/codes_ui/codes_ui.bat | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/metview/src/codes_ui/codes_ui.bat b/metview/src/codes_ui/codes_ui.bat
+index 0e20e83..61a3d6e 100644
+--- a/metview/src/codes_ui/codes_ui.bat
++++ b/metview/src/codes_ui/codes_ui.bat
+@@ -15,4 +15,7 @@
+ set args=%*
+ set args=%args:\=/%
+ 
+-bash -c "codes_ui %args%"
++set codes_ui_dir=%~dp0
++set codes_ui_dir=%codes_ui_dir:\=/%
++
++bash -c "%codes_ui_dir%/codes_ui %args%"
+-- 
+2.19.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://confluence.ecmwf.int/download/attachments/30048389/Metview-{{ metview_version }}-dev4-Source.tar.gz
   sha256: f0eee5fc7a546387af8b02cb345e7246f6611ecf55683cee2bdc37b3abba2ec5
+  patches:
+    - 0001-Give-absolute-path-to-codes_ui-launch-script.patch
 
 build:
-  number: 1003
+  number: 1004
   skip: True  # [(win and vc<14)]
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
